### PR TITLE
Added the after course end date condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Restrict module and section access based on relative dates.
 # Idea
 This availability condition makes it easy to show modules or sections only x days/weeks/months
   - after course start date
+  - after course end date
   - before course end date
   - after user enrolment date
-  - after end of enrloment period
+  - after end of enrolment period
 
 # Conditional availability conditions
 Check the global documentation about conditional availability conditions:

--- a/classes/condition.php
+++ b/classes/condition.php
@@ -57,6 +57,7 @@ class condition extends \core_availability\condition {
      * 2 => Before Course end date
      * 3 => After User enrolment date
      * 4 => After Enrolment method end date
+     * 5 => After Course end date
      */
     private $relativestart;
 
@@ -164,6 +165,8 @@ class condition extends \core_availability\condition {
                 return get_string('dateenrol', 'availability_relativedate');
             case 4:
                 return get_string('dateendenrol', 'availability_relativedate');
+            case 5:
+                return get_string('afterdateend', 'availability_relativedate');
         }
         return '';
     }
@@ -248,6 +251,9 @@ class condition extends \core_availability\condition {
             if ($lowest > 0) {
                 return $this->fixdate("+$this->relativenumber $x", $lowest);
             }
+        } else if ($this->relativestart == 5 && isset($course->enddate) && $course->enddate != 0) {
+            // Course end date.
+            return $this->fixdate("+$this->relativenumber $x", $course->enddate);
         }
         return 0;
     }

--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -53,6 +53,7 @@ class frontend extends \core_availability\frontend {
         global $DB;
         $optionsdwm = self::convert_associative_array_for_js(condition::options_dwm(), 'field', 'display');
         $optionsstart = [(object)['field' => 1, 'display' => condition::options_start(1)],
+                         (object)['field' => 5, 'display' => condition::options_start(5)],
                          (object)['field' => 2, 'display' => condition::options_start(2)],
                          (object)['field' => 3, 'display' => condition::options_start(3)]];
         if ($DB->count_records_select('enrol', 'courseid = :courseid AND enrolenddate > 0', ['courseid' => $course->id]) > 0) {

--- a/lang/en/availability_relativedate.php
+++ b/lang/en/availability_relativedate.php
@@ -26,6 +26,7 @@
 $string['after'] = ' after ';
 $string['before'] = ' before ';
 $string['dateend'] = 'before course end date';
+$string['afterdateend'] = 'after course end date';
 $string['dateenrol'] = 'after user enrolment date';
 $string['dateendenrol'] = 'after enrolment method end date';
 $string['datestart'] = 'after course start date';

--- a/tests/condition_test.php
+++ b/tests/condition_test.php
@@ -75,12 +75,15 @@ class condition_test extends \advanced_testcase {
             'c' => [(object)['type' => 'relativedate', 'n' => 5, 'd' => 4, 's' => 4]]];
         $stru6 = (object)['op' => '|', 'show' => false,
             'c' => [(object)['type' => 'relativedate', 'n' => 5, 'd' => 5, 's' => 5]]];
+        $stru7 = (object)['op' => '|', 'show' => false,
+            'c' => [(object)['type' => 'relativedate', 'n' => 6, 'd' => 6, 's' => 6]]];
         $tree1 = new tree($stru1);
         $tree2 = new tree($stru2);
         $tree3 = new tree($stru3);
         $tree4 = new tree($stru4);
         $tree5 = new tree($stru5);
         $tree6 = new tree($stru6);
+        $tree7 = new tree($stru7);
 
         $studentroleid = $DB->get_field('role', 'id', ['shortname' => 'student']);
         $now = time();
@@ -123,6 +126,7 @@ class condition_test extends \advanced_testcase {
         $this->assertFalse($tree4->is_available_for_all());
         $this->assertFalse($tree5->is_available_for_all());
         $this->assertFalse($tree6->is_available_for_all());
+        $this->assertFalse($tree7->is_available_for_all());
         $this->assertFalse($tree1->check_available(false, $info, false, 0)->is_available());
         $this->assertFalse($tree1->check_available(false, $info, false, $user->id)->is_available());
         $this->assertFalse($tree2->check_available(false, $info, false, $user->id)->is_available());
@@ -130,13 +134,15 @@ class condition_test extends \advanced_testcase {
         $this->assertFalse($tree4->check_available(false, $info, false, $user->id)->is_available());
         $this->assertFalse($tree5->check_available(false, $info, false, $user->id)->is_available());
         $this->assertFalse($tree6->check_available(false, $info, false, $user->id)->is_available());
+        $this->assertFalse($tree7->check_available(false, $info, false, $user->id)->is_available());
         $this->assertTrue($tree1->check_available(true, $info, false, 0)->is_available());
         $this->assertTrue($tree1->check_available(true, $info, false, $user->id)->is_available());
         $this->assertTrue($tree2->check_available(true, $info, false, $user->id)->is_available());
         $this->assertTrue($tree3->check_available(true, $info, false, $user->id)->is_available());
         $this->assertTrue($tree4->check_available(true, $info, false, $user->id)->is_available());
         $this->assertTrue($tree5->check_available(true, $info, false, $user->id)->is_available());
-        $this->assertFalse($tree6->check_available(true, $info, false, $user->id)->is_available());
+        $this->assertTrue($tree6->check_available(true, $info, false, $user->id)->is_available());
+        $this->assertFalse($tree7->check_available(true, $info, false, $user->id)->is_available());
     }
 
     /**
@@ -317,6 +323,7 @@ class condition_test extends \advanced_testcase {
         $this->assertEquals('before course end date', \availability_relativedate\condition::options_start(2));
         $this->assertEquals('after user enrolment date', \availability_relativedate\condition::options_start(3));
         $this->assertEquals('after enrolment method end date', \availability_relativedate\condition::options_start(4));
-        $this->assertEquals('', \availability_relativedate\condition::options_start(5));
+        $this->assertEquals('after course end date', \availability_relativedate\condition::options_start(5));
+        $this->assertEquals('', \availability_relativedate\condition::options_start(6));
     }
 }


### PR DESCRIPTION
Use case:
We would like our evaluations and course certificates to be automatically shown after the course has ended. It seems weird for the students to receive such before the course has ended.

Thanks for having a look at my PR :)