### PR TITLE
Fixed error where course module would not be set and would try to get id

### DIFF
--- a/classes/condition.php
+++ b/classes/condition.php
@@ -275,7 +275,7 @@ class condition extends \core_availability\condition {
                 }
                 return $this->fixdate("+$x", $lowest);
             case 4:
-                // Aftr latest enrolment end date.
+                // After latest enrolment end date.
                 $sql = 'SELECT e.enrolenddate
                         FROM {user_enrolments} ue
                         JOIN {enrol} e on ue.enrolid = e.id
@@ -285,6 +285,11 @@ class condition extends \core_availability\condition {
                 return $this->fixdate("+$x", $lowest);
             case 7:
                 // Since completion of a module.
+
+                if ($this->relativecoursemodule < 1) {
+                    return 0;
+                }
+
                 $cm = new stdClass;
                 $cm->id = $this->relativecoursemodule;
                 $cm->course = $course->id;

--- a/version.php
+++ b/version.php
@@ -29,5 +29,5 @@ $plugin->component = 'availability_relativedate';
 $plugin->requires = 2021051700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [311, 402];
-$plugin->release = 'v4.0.7';
-$plugin->version = 2023060300;
+$plugin->release = 'v4.0.8';
+$plugin->version = 2023080900;


### PR DESCRIPTION
Hello @ewallah

I found a bug, as you've seen too, that when updating the modules $this->cmid would be set instead of $this->relativecoursemodule - The main problem there was that if it was possible for an activity to rely on a non-existing activity, it would throw an error, cause it could not find the course module. But that is now fixed with your latest update.

How to replicate current error I'm still experiencing;
1. Create a courses (C1)
2. Create 2 activities in C1 (A1 & A2)
2.1. Give A2 a restrict access on A1 using "After completion of activity"
3. Backup course C1 only with the activity A2
4. Restore course as a new course

This should throw an error, since the course module should have a valid id. This PR should fix that problem, and instead of an error just shows the activity as missing.

I've hereto updated tests to test on all the 7 different cases that can happen, hereto for their debug string. Also updated a test, that had no assertions.

Thank you for looking at this!

Kind regards,
Anders Rasmussen